### PR TITLE
Install package elm-explorations/test after uninstalling master

### DIFF
--- a/lib/elm-test.js
+++ b/lib/elm-test.js
@@ -284,14 +284,32 @@ function main() {
       'Stop using the `master` version of the elm-explorations/test library'
     )
     .action(() => {
+      const options = program.opts();
+      const pathToElmBinary = getPathToElmBinary(options.compiler);
       const project = getProject('uninstall-unstable-test-master');
-      try {
+      const run = async () => {
         Install.uninstallUnstableTestMaster(project);
-        process.exit(0);
-      } catch (error) {
-        console.error(error.message);
-        process.exit(1);
-      }
+        // Install project elm-explorations/test again. This is based on the `make` command.
+        Generate.generateElmJson(dependencyProvider, project);
+        const dummyFile = path.join(project.generatedCodeDir, 'Dummy.elm');
+        fs.writeFileSync(
+          dummyFile,
+          `module Dummy exposing (dummy)\ndummy = ()`
+        );
+        await Compile.compileSources(
+          [dummyFile],
+          project.generatedCodeDir,
+          pathToElmBinary,
+          options.report
+        );
+      };
+      run().then(
+        () => process.exit(0),
+        (error) => {
+          console.error(error.message);
+          process.exit(1);
+        }
+      );
     });
 
   program.parse(process.argv);


### PR DESCRIPTION
Fixes https://github.com/rtfeldman/node-test-runner/pull/592#issuecomment-1141280951

I noticed that intellij-elm doesn’t mind the `master` version after all. What it is struggling with is when you open a project but `elm-explorations/test` is _missing._ Which it is after running `elm-test uninstall-unstable-test-master`.

This PR restores the original package on uninstall, by compiling a dummy file inside the generated code dir. (That’s the approach elm-watch uses to install packages, btw.)